### PR TITLE
Save array of CSS files as a variable

### DIFF
--- a/template.php
+++ b/template.php
@@ -49,4 +49,12 @@ function stanford_light_preprocess_page(&$vars) {
   }
 
   $vars['styles'] = drupal_get_css();
+
+  // Save our CSS for the WYSIWYG to use.
+  $wysiwyg_css = drupal_add_css();
+  $css_files = array();
+  foreach ($wysiwyg_css as $wysiwyg_css_file) {
+    $css_files[] = $wysiwyg_css_file['data'];
+  }
+  variable_set('stanford_light_wysiwyg_css', $css_files);
 }


### PR DESCRIPTION
@hyperboy see https://stanfordits.atlassian.net/browse/BASIC-1118.

This change has the theme compute all the CSS files that it's loading, then save that array as a variable.